### PR TITLE
Add monitoring endpoints and alternative data agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI Hedge Fund
 
+For a detailed architecture overview, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 This is a proof of concept for an AI-powered hedge fund.  The goal of this project is to explore the use of AI to make trading decisions.  This project is for **educational** purposes only and is not intended for real trading or investment.
 
 This system employs several agents working together:
@@ -39,6 +41,8 @@ This project is for **educational and research purposes only**.
 - Past performance does not indicate future results
 
 By using this software, you agree to use it solely for learning purposes.
+
+The architecture integrates optional **alternative data sources** like satellite foot traffic and credit card analytics. A FastAPI backend exposes monitoring endpoints under `/monitor` for signals, orders, risk, performance, and latency.
 
 ## Table of Contents
 - [Setup](#setup)

--- a/app/backend/routes/__init__.py
+++ b/app/backend/routes/__init__.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.backend.routes.hedge_fund import router as hedge_fund_router
 from app.backend.routes.health import router as health_router
+from app.backend.routes.monitoring import router as monitoring_router
 
 # Main API router
 api_router = APIRouter()
@@ -9,3 +10,4 @@ api_router = APIRouter()
 # Include sub-routers
 api_router.include_router(health_router, tags=["health"])
 api_router.include_router(hedge_fund_router, tags=["hedge-fund"])
+api_router.include_router(monitoring_router, tags=["monitor"])

--- a/app/backend/routes/monitoring.py
+++ b/app/backend/routes/monitoring.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter
+from src.data import store
+
+router = APIRouter(prefix="/monitor")
+
+
+@router.get("/signals")
+def get_signals():
+    return {"signals": store.signals}
+
+
+@router.get("/orders")
+def get_orders():
+    return {"orders": store.orders}
+
+
+@router.get("/risk")
+def get_risk():
+    return {"risk": store.risk_metrics}
+
+
+@router.get("/performance")
+def get_performance():
+    return {"performance": store.performance}
+
+
+@router.get("/latency")
+def get_latency():
+    return {"latency": store.latency}
+
+
+@router.get("/health")
+def get_health():
+    return {"status": "ok"}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,83 @@
+# AI-Driven Multi-Agent Hedge Fund Architecture
+
+This document restructures the hedge fund design described in the repository, capturing all details of the proposed multi-agent system. The system targets U.S. equities and ETFs on a daily to multi-day horizon. It is implemented in Python 3.11 and uses Docker Compose for orchestration.
+
+## 1. Agent Lineup
+
+The framework combines analytic agents with investor persona agents to diversify alpha sources:
+
+### Analytic Agents
+- **Valuation Agent** – Performs discounted cash flow and relative valuation. Buys stocks far below intrinsic value and shorts extreme overvaluation.
+- **Fundamentals Agent** – Focuses on business quality and growth metrics. Prefers strong earnings growth, high ROE, and healthy cash flow trends.
+- **Technicals Agent** – Detects momentum bursts or mean-reversion using MA crossovers, RSI, MACD, etc.
+- **Sentiment Agent** – Monitors news and social media sentiment to trade ahead of crowd psychology swings.
+- **Macro Agent** – Adjusts exposure based on economic indicators and broad market trends.
+
+### Investor-Persona Agents
+- **Warren Buffett Agent** – Buys "wonderful" companies with durable moats at fair or bargain prices.
+- **Peter Lynch Agent** – Seeks growth at a reasonable price, favoring low PEG stocks with potential to become "ten-baggers." 
+- **Michael Burry Agent** – Contrarian deep-value approach; buys neglected stocks at very low multiples and shorts bubbles.
+
+Other persona agents (e.g., Ben Graham, Stanley Druckenmiller) can be added similarly.
+
+## 2. Signal Fusion
+
+Signals from all agents are combined using a weighted ensemble. Weights adapt to recent performance and market regime. A Bayesian or meta-learning approach can be used to update weights over time. Conflict resolution rules prevent extreme trades when agents disagree strongly.
+
+## 3. Data & Infrastructure
+
+- **Data Sources:** Real-time price feeds (Alpha Vantage, Polygon.io, Tiingo, IEX Cloud), fundamentals (FMP, Alpha Vantage, Tiingo), news and sentiment (NewsAPI, Finnhub, Polygon), and alternative data (SimilarWeb, Google Trends, Quiver Quant).
+- **Alternative Data Examples:** Satellite foot traffic (Orbital Insight, RS Metrics), credit card analytics (Second Measure, Earnest Analytics), social chatter (Reddit/StockTwits APIs), web analytics (Thinknum, Similarweb), ESG scores (RepRisk), and supply chain data (Panjiva).
+- **Architecture:** Containers for each service. A FastAPI ingestion service streams data into Kafka topics, caches latest quotes in Redis, and stores history in Postgres. Agents subscribe to Kafka or Redis to access data. Optional Spark can scale heavy processing.
+- **Tools:** SQLAlchemy for Postgres interaction, httpx for API requests, confluent-kafka/aiokafka for Kafka. FastAPI orchestrates tasks and exposes endpoints. Everything is containerized in Docker Compose for portability.
+
+## 4. Risk & Capital Allocation
+
+- **Fractional Kelly Sizing:** Position sizes are based on a half-Kelly fraction adjusted for asset volatility.
+- **CVaR and Volatility Constraints:** Portfolio-level caps on expected shortfall and target volatility. Drawdown triggers, gross/net exposure limits, and liquidity checks are enforced.
+- **Example:** Kelly suggests 25% allocation to a trade; volatility and CVaR rules might reduce this to 4–6% of capital.
+
+## 5. Execution & Monitoring
+
+1. Agents generate signals which are fused into target portfolio weights.
+2. An order blotter translates weight changes into broker orders via an abstraction layer (e.g., Alpaca or Interactive Brokers).
+3. Slippage and transaction costs are modeled; large orders are sliced to reduce market impact.
+4. A monitoring dashboard (Plotly Dash or Streamlit) shows live P&L, exposures, and risk metrics.
+5. All trades and agent outputs are logged in Postgres for audit and analysis.
+
+### Internal REST Endpoints
+
+The FastAPI service exposes lightweight endpoints so agents and dashboards can share data:
+
+- `GET /monitor/signals` – latest signals from each agent
+- `GET /monitor/orders` – recently generated orders
+- `GET /monitor/risk` – current risk metrics
+- `GET /monitor/performance` – portfolio performance stats
+- `GET /monitor/latency` – simple latency telemetry
+- `GET /monitor/health` – service heartbeat
+
+## 6. Continuous Learning
+
+- Agents with ML models are retrained regularly on new data. A nightly job updates datasets and re-trains models.
+- Trade outcomes feed back into a performance database. Poorly performing agents are pruned or retrained, and new experimental agents can be incubated.
+- Ensemble weights are periodically re-optimized using recent data and market regime classifiers.
+
+## 7. Example Daily Routine
+
+1. **Pre-market:** Data ingestion service collects overnight news and price data. Agents update signals.
+2. **Signal Fusion:** Ensemble weights combine agent views on each ticker (e.g., AAPL, SPY, TSLA).
+3. **Risk Checks:** Risk manager evaluates proposed positions for Kelly sizing, CVaR limits, and exposure caps.
+4. **Execution:** Orders are sent to the broker before market close or at predefined times.
+5. **Monitoring:** Dashboard tracks intraday P&L. Agents continue ingesting data for next-day decisions.
+6. **End-of-day:** Trades are logged, performance metrics updated, and training jobs queued if scheduled.
+
+## 8. Building on Windows 11 with WSL
+
+Follow the project README for installation. In brief:
+1. Clone the repository and install [Poetry](https://python-poetry.org) inside WSL.
+2. Run `poetry install` to install dependencies.
+3. Copy `.env.example` to `.env` and provide API keys for OpenAI, Groq, and Financial Datasets.
+4. Run with `poetry run python src/main.py --ticker AAPL,MSFT,NVDA` or use Docker via `./run.sh build` then `./run.sh --ticker AAPL,MSFT,NVDA main`.
+
+For other details, see [README.md](../README.md).
+

--- a/src/agents/alt_data_agent.py
+++ b/src/agents/alt_data_agent.py
@@ -1,0 +1,35 @@
+from langchain_core.messages import HumanMessage
+from src.graph.state import AgentState, show_agent_reasoning
+from src.utils.progress import progress
+from src.tools import alt_data
+from src.data import store
+import json
+
+
+def alt_data_agent(state: AgentState):
+    """Fetch alternative data signals for each ticker."""
+    tickers = state["data"]["tickers"]
+    signals = {}
+
+    for ticker in tickers:
+        progress.update_status("alt_data_agent", ticker, "Collecting data")
+        reddit = alt_data.get_reddit_mentions(ticker)
+        stwits = alt_data.get_stocktwits_sentiment(ticker)
+        sales = alt_data.get_second_measure_sales(ticker)
+
+        signals[ticker] = {
+            "reddit": reddit,
+            "stocktwits": stwits,
+            "sales": sales,
+        }
+        store.record_signal({"ticker": ticker, "alt_data": signals[ticker]})
+        progress.update_status("alt_data_agent", ticker, "Done")
+
+    message = HumanMessage(content=json.dumps(signals), name="alt_data_agent")
+
+    if state["metadata"].get("show_reasoning"):
+        show_agent_reasoning(signals, "Alt Data Agent")
+
+    state["data"]["analyst_signals"]["alt_data_agent"] = signals
+
+    return {"messages": state["messages"] + [message], "data": state["data"]}

--- a/src/agents/portfolio_manager.py
+++ b/src/agents/portfolio_manager.py
@@ -6,6 +6,7 @@ from src.graph.state import AgentState, show_agent_reasoning
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 from src.utils.progress import progress
+from src.data import store
 from src.utils.llm import call_llm
 
 
@@ -73,6 +74,10 @@ def portfolio_management_agent(state: AgentState):
         content=json.dumps({ticker: decision.model_dump() for ticker, decision in result.decisions.items()}),
         name="portfolio_manager",
     )
+
+    # Record orders in the store
+    for ticker, decision in result.decisions.items():
+        store.record_order({"ticker": ticker, **decision.model_dump()})
 
     # Print the decision if the flag is set
     if state["metadata"]["show_reasoning"]:

--- a/src/agents/risk_manager.py
+++ b/src/agents/risk_manager.py
@@ -2,6 +2,7 @@ from langchain_core.messages import HumanMessage
 from src.graph.state import AgentState, show_agent_reasoning
 from src.utils.progress import progress
 from src.tools.api import get_prices, prices_to_df
+from src.data import store
 import json
 
 
@@ -18,10 +19,10 @@ def risk_management_agent(state: AgentState):
 
     # First, fetch prices for all relevant tickers
     all_tickers = set(tickers) | set(portfolio.get("positions", {}).keys())
-    
+
     for ticker in all_tickers:
         progress.update_status("risk_management_agent", ticker, "Fetching price data")
-        
+
         prices = get_prices(
             ticker=ticker,
             start_date=data["end_date"],  # Just get the latest price
@@ -33,7 +34,7 @@ def risk_management_agent(state: AgentState):
             continue
 
         prices_df = prices_to_df(prices)
-        
+
         if not prices_df.empty:
             current_price = prices_df["close"].iloc[-1]
             current_prices[ticker] = current_price
@@ -43,48 +44,42 @@ def risk_management_agent(state: AgentState):
 
     # Calculate total portfolio value based on current market prices (Net Liquidation Value)
     total_portfolio_value = portfolio.get("cash", 0.0)
-    
+
     for ticker, position in portfolio.get("positions", {}).items():
         if ticker in current_prices:
             # Add market value of long positions
             total_portfolio_value += position.get("long", 0) * current_prices[ticker]
             # Subtract market value of short positions
             total_portfolio_value -= position.get("short", 0) * current_prices[ticker]
-    
+
     progress.update_status("risk_management_agent", None, f"Total portfolio value: {total_portfolio_value}")
 
     # Calculate risk limits for each ticker in the universe
     for ticker in tickers:
         progress.update_status("risk_management_agent", ticker, "Calculating position limits")
-        
+
         if ticker not in current_prices:
             progress.update_status("risk_management_agent", ticker, "Failed: No price data available")
-            risk_analysis[ticker] = {
-                "remaining_position_limit": 0.0,
-                "current_price": 0.0,
-                "reasoning": {
-                    "error": "Missing price data for risk calculation"
-                }
-            }
+            risk_analysis[ticker] = {"remaining_position_limit": 0.0, "current_price": 0.0, "reasoning": {"error": "Missing price data for risk calculation"}}
             continue
-            
+
         current_price = current_prices[ticker]
-        
+
         # Calculate current market value of this position
         position = portfolio.get("positions", {}).get(ticker, {})
         long_value = position.get("long", 0) * current_price
         short_value = position.get("short", 0) * current_price
         current_position_value = abs(long_value - short_value)  # Use absolute exposure
-        
+
         # Calculate position limit (20% of total portfolio)
         position_limit = total_portfolio_value * 0.20
-        
+
         # Calculate remaining limit for this position
         remaining_position_limit = position_limit - current_position_value
-        
+
         # Ensure we don't exceed available cash
         max_position_size = min(remaining_position_limit, portfolio.get("cash", 0))
-        
+
         risk_analysis[ticker] = {
             "remaining_position_limit": float(max_position_size),
             "current_price": float(current_price),
@@ -96,7 +91,7 @@ def risk_management_agent(state: AgentState):
                 "available_cash": float(portfolio.get("cash", 0)),
             },
         }
-        
+
         progress.update_status("risk_management_agent", ticker, "Done")
 
     message = HumanMessage(
@@ -107,8 +102,9 @@ def risk_management_agent(state: AgentState):
     if state["metadata"]["show_reasoning"]:
         show_agent_reasoning(risk_analysis, "Risk Management Agent")
 
-    # Add the signal to the analyst_signals list
+    # Add the signal to the analyst_signals list and store
     state["data"]["analyst_signals"]["risk_management_agent"] = risk_analysis
+    store.update_risk(risk_analysis)
 
     return {
         "messages": state["messages"] + [message],

--- a/src/data/store.py
+++ b/src/data/store.py
@@ -1,0 +1,32 @@
+"""Simple in-memory store for API endpoints."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+signals: List[Dict[str, Any]] = []
+orders: List[Dict[str, Any]] = []
+risk_metrics: Dict[str, Any] = {}
+performance: Dict[str, Any] = {}
+latency: Dict[str, Any] = {}
+
+
+def record_signal(signal: Dict[str, Any]):
+    signals.append(signal)
+
+
+def record_order(order: Dict[str, Any]):
+    orders.append(order)
+
+
+def update_risk(data: Dict[str, Any]):
+    risk_metrics.update(data)
+
+
+def update_performance(data: Dict[str, Any]):
+    performance.update(data)
+
+
+def update_latency(data: Dict[str, Any]):
+    latency.update(data)

--- a/src/tools/alt_data.py
+++ b/src/tools/alt_data.py
@@ -1,0 +1,36 @@
+"""Utility stubs for alternative market data.
+
+These functions simulate calls to satellite imagery,
+consumer spending, social sentiment, and web analytics
+providers. Real implementations would call vendor APIs,
+but these placeholders keep the project self-contained.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def get_orbital_insight_traffic(location: str) -> Dict[str, Any]:
+    """Return mocked foot traffic metrics for a location."""
+    return {"location": location, "traffic_index": 50}
+
+
+def get_second_measure_sales(ticker: str) -> Dict[str, Any]:
+    """Return mocked credit card sales growth data for a ticker."""
+    return {"ticker": ticker, "sales_growth": 0.05}
+
+
+def get_reddit_mentions(ticker: str) -> Dict[str, Any]:
+    """Return mocked Reddit mention counts and sentiment."""
+    return {"ticker": ticker, "mention_count": 0, "sentiment": 0.0}
+
+
+def get_stocktwits_sentiment(ticker: str) -> Dict[str, Any]:
+    """Return mocked StockTwits sentiment score."""
+    return {"ticker": ticker, "sentiment_score": 0.0}
+
+
+def get_similarweb_visits(domain: str) -> Dict[str, Any]:
+    """Return mocked web traffic numbers for a domain."""
+    return {"domain": domain, "visits": 0}

--- a/src/utils/analysts.py
+++ b/src/utils/analysts.py
@@ -14,6 +14,7 @@ from src.agents.stanley_druckenmiller import stanley_druckenmiller_agent
 from src.agents.technicals import technical_analyst_agent
 from src.agents.valuation import valuation_agent
 from src.agents.warren_buffett import warren_buffett_agent
+from src.agents.alt_data_agent import alt_data_agent
 
 # Define analyst configuration - single source of truth
 ANALYST_CONFIG = {
@@ -86,6 +87,11 @@ ANALYST_CONFIG = {
         "display_name": "Valuation Analyst",
         "agent_func": valuation_agent,
         "order": 13,
+    },
+    "alt_data": {
+        "display_name": "Alt Data Analyst",
+        "agent_func": alt_data_agent,
+        "order": 14,
     },
 }
 


### PR DESCRIPTION
## Summary
- integrate optional alternative data agent
- store signals and orders for monitoring
- expose new `/monitor` API routes
- document alternative data sources and REST endpoints

## Testing
- `black --check .`
- `pytest -q`